### PR TITLE
Use relative reference to metrics.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>1.7</maven.compiler.source>
         <maven.compiler.target>1.7</maven.compiler.target>
-        <dropwizard.version>1.3.7</dropwizard.version>
+        <dropwizard.version>1.3.8</dropwizard.version>
     </properties>
 
     <dependencyManagement>

--- a/src/main/webapp/src/App.js
+++ b/src/main/webapp/src/App.js
@@ -41,7 +41,7 @@ class App extends Component {
     }
 
     timer() {
-        fetch('/metrics')
+        fetch('metrics')
             .then(response => response.json())
             .then(responseJson => this.setState({
                 ts: new Date(),


### PR DESCRIPTION
If you set to admin context with path `/admin`, then the frontend part of dropwizard-metrics-ui will go to wrong non-relative path, to `/metrics`, but should to `/admin/metrics`.
I fixed it.

I also updated the version of Dropwizard to 1.3.8.